### PR TITLE
Added ability to stop CurrentTime update thread

### DIFF
--- a/src/main/java/gov/usgs/volcanoes/core/time/CurrentTime.java
+++ b/src/main/java/gov/usgs/volcanoes/core/time/CurrentTime.java
@@ -98,6 +98,9 @@ public class CurrentTime {
 
   private int timeout = DEFAULT_TIMEOUT;
 
+  private boolean running = true;
+  private Thread offsetUpdater;
+
   /**
    * Default constructor.
    */
@@ -120,14 +123,15 @@ public class CurrentTime {
           DEFAULT_RECALIBRATION_INTERVAL);
     }
 
-    new Thread(offsetUpdater()).start();
+    offsetUpdater = new Thread(offsetUpdater());
+    offsetUpdater.start();
 
   }
 
   private Runnable offsetUpdater() {
     Runnable run = new Runnable() {
       public void run() {
-        while (true) {
+        while (running) {
           getOffset();
           try {
             Thread.sleep(recalibrationInterval);
@@ -251,4 +255,13 @@ public class CurrentTime {
   public void setRecalibrationInterval(long ms) {
     recalibrationInterval = ms;
   }
+
+  /**
+   * Stops the update thread so that programs relying on this class can shutdown nicely.
+   */
+  public void stopUpdating() {
+    running = false;
+    offsetUpdater.interrupt();
+  }
+
 }

--- a/src/test/java/gov/usgs/volcanoes/core/util/StringUtilsTest.java
+++ b/src/test/java/gov/usgs/volcanoes/core/util/StringUtilsTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.Test;
 
 public class StringUtilsTest {
@@ -76,7 +77,9 @@ public class StringUtilsTest {
     Map<String, String> input = new HashMap<String, String>();
     input.put("key1", "val1");
     input.put("key2", "val2");
-    assertTrue("key1=val1; key2=val2; ".equals(StringUtils.mapToString(input)));
+    System.out.println("TOMP SAYS: " + StringUtils.mapToString(input));
+    assertTrue("key1=val1; key2=val2; ".equals(StringUtils.mapToString(input))
+        || "key2=val2; key1=val1; ".equals(StringUtils.mapToString(input)));
   }
 
   @Test


### PR DESCRIPTION
This is necessary for any programs that depend on the CurrentTime class to shutdown nicely. As long as the thread is running, the overall program will wait.